### PR TITLE
Updating Tailwind CSS to 2.0

### DIFF
--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -53,7 +53,7 @@ blockquote > p {
     @apply bg-ne-surface-darker;
 }
 .article-container tbody tr:hover {
-    @apply bg-gray-600;
+    @apply bg-ne-on-surface;
 }
 
 .article-container figcaption {
@@ -69,11 +69,7 @@ section.footnotes:before {
 }
 
 .post-footer {
-    @apply text-ne-on-surface-dark;
-}
-
-a.post-footer:hover {
-    @apply text-ne-on-background-dark;
+    @apply text-ne-on-surface-dark hover:text-ne-on-surface-dark;
 }
 
 .post-footer tr:hover {
@@ -97,6 +93,10 @@ a.post-footer:hover {
     @apply bg-ne-background-dark;
 }
 
+#toc-top-divider {
+    @apply border-ne-surface-dark;
+}
+
 #toc-top-divider::after {
     @apply text-ne-on-surface-dark bg-ne-background-dark;
 }
@@ -111,7 +111,7 @@ a.post-footer:hover {
     @apply bg-ne-surface-darker;
 }
 #search-input {
-    @apply border-b border-ne-surface-dark;
+    @apply border-b border-ne-surface-dark text-ne-on-surface-dark;
 }
 #search-input input {
     @apply bg-ne-surface-darker text-ne-on-surface-dark;
@@ -143,12 +143,12 @@ ul.search-results li:hover {
 
 /* Unified buttons style */
 .round-button {
-    @apply rounded-full shadow-md bg-ne-surface-dark transition-all duration-150 ease-linear;
+    @apply bg-ne-surface-dark;
 }
 
 .round-button button,
 button.round-button {
-    @apply font-bold text-ne-on-surface-dark hover:text-ne-on-primary;
+    @apply text-ne-on-surface-dark hover:text-ne-on-primary;
 }
 
 /* Site header */
@@ -157,20 +157,20 @@ button.round-button {
 }
 
 .site-header-navlink:hover {
-    @apply bg-gray-400 text-gray-700;
+    @apply bg-ne-surface-dark text-ne-on-surface-lighter;
 }
 
 /* Publication related */
 #publication-metadata {
-    @apply text-gray-300;
+    @apply text-ne-on-surface-dark;
 }
 
 .listview-wrapper {
-    @apply text-gray-300;
+    @apply text-ne-on-surface-dark;
 }
 
-.listview-row:hover {
-    @apply bg-gray-400 text-gray-700;
+.listview-row {
+    @apply hover:bg-ne-surface-dark hover:text-ne-on-background-dark transition-all duration-150 ease-linear;
 }
 
 /* Styling cards and elements */
@@ -179,11 +179,7 @@ button.round-button {
 }
 
 .gray-tag {
-    @apply text-ne-on-surface-dark bg-ne-surface-dark;
-}
-
-.gray-tag:hover {
-    @apply text-ne-on-primary;
+    @apply text-ne-on-surface-dark bg-ne-surface-dark hover:text-ne-on-primary hover:bg-ne-primary-dark;
 }
 
 /* Homepage pagination */

--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -1,6 +1,6 @@
 /* Text elements */
 body {
-    @apply bg-gray-800;
+    @apply bg-ne-background-dark;
 }
 
 h1,
@@ -9,23 +9,23 @@ h3,
 h4,
 h5,
 h6 {
-    @apply text-gray-200;
+    @apply text-ne-on-background-dark;
 }
 
 p {
-    @apply text-gray-300;
+    @apply text-ne-on-background-dark;
 }
 
 mark {
-    @apply bg-yellow-500;
+    @apply bg-ne-primary-darker;
 }
 
-blockquote {
-    @apply border-yellow-500 bg-gray-700;
+blockquote > p {
+    @apply text-ne-on-surface-dark;
 }
 
 :not(pre) > code {
-    @apply text-red-600 bg-red-200 rounded-sm;
+    @apply text-ne-on-error-dark bg-ne-error-dark rounded-sm;
 }
 
 .article-container img {
@@ -37,146 +37,127 @@ blockquote {
 }
 
 .article-container a {
-    @apply text-blue-300;
+    @apply text-ne-secondary-dark;
 }
 
 .article-container ul,
 .article-container ol {
-    @apply text-gray-300;
+    @apply text-ne-on-background-dark;
 }
 
 .article-container table {
-    @apply bg-gray-800 border-gray-400 text-gray-300;
+    @apply bg-ne-background-dark border-ne-surface-dark text-ne-on-background-dark;
 }
 
 .article-container tbody tr:nth-child(even) {
-    @apply bg-gray-700;
+    @apply bg-ne-surface-darker;
 }
 .article-container tbody tr:hover {
     @apply bg-gray-600;
 }
 
 .article-container figcaption {
-    @apply text-gray-300;
+    @apply text-ne-on-surface-dark;
 }
 
 .article-container .alert-warning {
-    @apply text-red-600 bg-red-200;
+    @apply text-ne-on-error-dark bg-ne-error-dark;
 }
 
 section.footnotes:before {
-    @apply text-gray-500 bg-gray-800;
+    @apply text-ne-on-surface-dark bg-ne-background-dark;
 }
 
-/* TOC and search screen */
+.post-footer {
+    @apply text-ne-on-surface-dark;
+}
+
+a.post-footer:hover {
+    @apply text-ne-on-background-dark;
+}
+
+.post-footer tr:hover {
+    @apply text-ne-on-background-dark;
+}
+
+.post-summary {
+    @apply text-ne-on-surface-dark;
+}
+
+/* Sidebar table of contents */
 #toc-list ol {
-    @apply text-gray-300 border-gray-300;
+    @apply text-ne-on-background-dark border-ne-surface-dark;
 }
 
 #toc-list a:hover {
-    @apply bg-gray-500;
+    @apply bg-ne-surface-dark;
 }
 
 #toc-container {
-    @apply bg-gray-800;
+    @apply bg-ne-background-dark;
 }
 
 #toc-top-divider::after {
-    @apply text-gray-500 bg-gray-800;
+    @apply text-ne-on-surface-dark bg-ne-background-dark;
 }
 
 #toc-background-mask,
 #search-screen {
-    background-color: rgba(20, 20, 20, 0.6);
+    @apply bg-ne-background-dark bg-opacity-60;
 }
 
+/* Search screen */
 #search-wrapper {
-    @apply bg-gray-800;
+    @apply bg-ne-surface-darker;
 }
 #search-input {
-    @apply border-b border-gray-700;
+    @apply border-b border-ne-surface-dark;
 }
 #search-input input {
-    @apply bg-gray-800 text-gray-300;
+    @apply bg-ne-surface-darker text-ne-on-surface-dark;
 }
 
 ul.search-results {
-    @apply text-gray-300;
+    @apply text-ne-on-surface-dark;
 }
 
 ul.search-results li {
-    @apply border-gray-600;
+    @apply border-ne-surface-dark;
 }
 
 ul.search-results li:hover {
-    @apply bg-gray-600;
+    @apply bg-ne-surface-dark;
 }
 
 .search-results .search-res-title {
-    @apply text-gray-200;
+    @apply text-ne-on-background-dark;
 }
 
 .search-results .search-res-date {
-    @apply text-gray-500;
+    @apply text-ne-on-surface;
 }
 
 .search-results .search-res-content {
-    @apply text-gray-300;
+    @apply text-ne-on-surface-dark;
 }
 
 /* Unified buttons style */
 .round-button {
-    @apply rounded-full shadow-md bg-gray-600 transition-all duration-150 ease-linear;
+    @apply rounded-full shadow-md bg-ne-surface-dark transition-all duration-150 ease-linear;
 }
 
 .round-button button,
 button.round-button {
-    @apply font-bold text-gray-200;
-}
-.round-button button:hover,
-button.round-button:hover {
-    @apply text-gray-700;
+    @apply font-bold text-ne-on-surface-dark hover:text-ne-on-primary;
 }
 
 /* Site header */
 #site-header {
-    @apply text-gray-300 text-lg;
-}
-
-#nav-homepage:hover {
-    @apply text-gray-400;
+    @apply border-b border-ne-surface-dark text-ne-on-surface-dark;
 }
 
 .site-header-navlink:hover {
     @apply bg-gray-400 text-gray-700;
-}
-
-.post-card {
-    @apply border border-gray-700 text-gray-300;
-}
-
-.gray-tag {
-    @apply text-gray-300 bg-gray-700;
-}
-
-.gray-tag:hover {
-    @apply text-gray-700;
-}
-
-.post-footer {
-    @apply text-gray-300;
-}
-
-a.post-footer:hover {
-    @apply text-gray-700;
-}
-
-.post-footer tr:hover {
-    @apply text-gray-800;
-}
-
-.post-summary {
-    @apply text-gray-500;
 }
 
 /* Publication related */
@@ -192,19 +173,36 @@ a.post-footer:hover {
     @apply bg-gray-400 text-gray-700;
 }
 
+/* Styling cards and elements */
+.post-card {
+    @apply border border-ne-surface-dark text-ne-on-background-dark;
+}
+
+.gray-tag {
+    @apply text-ne-on-surface-dark bg-ne-surface-dark;
+}
+
+.gray-tag:hover {
+    @apply text-ne-on-primary;
+}
+
 /* Homepage pagination */
 ul.pagination {
-    @apply border-gray-600;
+    @apply border-ne-surface-dark;
 }
 
 li.page-item {
-    @apply border-gray-600 text-gray-500;
+    @apply border-ne-surface-dark text-ne-on-surface-dark;
+}
+
+li.page-item:not(.disabled) {
+    @apply hover:bg-ne-surface-dark;
 }
 
 li.page-item.active {
-    @apply text-gray-400 border-t-2 border-yellow-400;
+    @apply text-ne-on-background-dark border-t-2 border-ne-primary-dark;
 }
 
 li.page-item.disabled {
-    @apply text-gray-700;
+    @apply text-ne-surface-dark;
 }

--- a/assets/css/light.css
+++ b/assets/css/light.css
@@ -95,7 +95,7 @@ section.footnotes:before {
     @apply bg-white shadow-md;
 }
 #search-input {
-    @apply border-b border-ne-surface;
+    @apply border-b border-ne-surface text-ne-on-surface;
 }
 #search-input input {
     @apply text-ne-surface-dark;
@@ -127,12 +127,12 @@ ul.search-results li:hover {
 
 /* Unified buttons style */
 .round-button {
-    @apply rounded-full shadow-md bg-white transition-all duration-150 ease-linear;
+    @apply shadow-md bg-white;
 }
 
 .round-button button,
 button.round-button {
-    @apply font-bold text-ne-on-background;
+    @apply text-ne-on-background;
 }
 
 /* Site header */
@@ -153,8 +153,8 @@ button.round-button {
     @apply text-ne-surface-dark;
 }
 
-.listview-row:hover {
-    @apply bg-ne-surface;
+.listview-row {
+    @apply hover:bg-ne-surface transition-all duration-150 ease-linear;
 }
 
 /* Styling cards and elements */
@@ -163,7 +163,7 @@ button.round-button {
 }
 
 .gray-tag {
-    @apply text-ne-surface-dark bg-ne-surface;
+    @apply text-ne-surface-dark bg-ne-surface hover:bg-ne-primary-dark;
 }
 
 /* Homepage pagination */
@@ -176,7 +176,7 @@ li.page-item {
 }
 
 li.page-item:not(.disabled) {
-    @apply rounded hover:bg-ne-surface;
+    @apply hover:bg-ne-surface;
 }
 
 li.page-item.active {

--- a/assets/css/light.css
+++ b/assets/css/light.css
@@ -61,6 +61,14 @@ section.footnotes:before {
     @apply text-ne-on-surface-lighter bg-white;
 }
 
+.post-footer {
+    @apply text-ne-surface-dark;
+}
+
+.post-summary {
+    @apply text-ne-on-surface;
+}
+
 /* TOC and search screen */
 #toc-list ol {
     @apply text-ne-on-background border-ne-surface;
@@ -80,7 +88,7 @@ section.footnotes:before {
 
 #toc-background-mask,
 #search-screen {
-    background-color: rgba(0, 0, 0, 0.6);
+    @apply bg-ne-background-dark bg-opacity-60;
 }
 
 #search-wrapper {
@@ -129,28 +137,11 @@ button.round-button {
 
 /* Site header */
 #site-header {
-    @apply bg-white text-ne-surface-dark text-lg shadow-sm;
+    @apply bg-white text-ne-surface-dark shadow-sm;
 }
 
 .site-header-navlink:hover {
     @apply bg-ne-surface;
-}
-
-/* Styling cards and elements */
-.post-card {
-    @apply bg-white text-ne-surface-dark;
-}
-
-.gray-tag {
-    @apply text-ne-surface-dark bg-ne-surface;
-}
-
-.post-footer {
-    @apply text-ne-surface-dark;
-}
-
-.post-summary {
-    @apply text-ne-on-surface;
 }
 
 /* Publication related */
@@ -166,6 +157,15 @@ button.round-button {
     @apply bg-ne-surface;
 }
 
+/* Styling cards and elements */
+.post-card {
+    @apply bg-white text-ne-surface-dark;
+}
+
+.gray-tag {
+    @apply text-ne-surface-dark bg-ne-surface;
+}
+
 /* Homepage pagination */
 ul.pagination {
     @apply border-ne-surface;
@@ -175,8 +175,12 @@ li.page-item {
     @apply border-ne-surface text-ne-on-surface;
 }
 
+li.page-item:not(.disabled) {
+    @apply rounded hover:bg-ne-surface;
+}
+
 li.page-item.active {
-    @apply text-ne-on-background border-ne-secondary;
+    @apply text-ne-on-background border-ne-primary-dark;
 }
 li.page-item.disabled {
     @apply text-ne-on-surface-lighter;

--- a/assets/css/light.css
+++ b/assets/css/light.css
@@ -1,6 +1,6 @@
 /* Background color for homepage only */
 .page-home {
-    @apply bg-gray-100;
+    @apply bg-ne-background;
 }
 
 /* Text elements */
@@ -10,64 +10,64 @@ h3,
 h4,
 h5,
 h6 {
-    @apply text-gray-800;
+    @apply text-ne-on-background;
 }
 
 p {
-    @apply text-gray-800;
+    @apply text-ne-on-background;
 }
 
 mark {
-    @apply bg-yellow-300;
+    @apply bg-ne-primary-dark;
 }
 
-blockquote {
-    @apply border-yellow-400 bg-yellow-100;
+blockquote > p {
+    @apply text-ne-on-surface;
 }
 
 :not(pre) > code {
-    @apply text-red-600 bg-red-100 rounded-sm;
+    @apply text-ne-on-error bg-ne-error rounded-sm;
 }
 
 .article-container a {
-    @apply text-blue-600;
+    @apply text-ne-secondary;
 }
 
 .article-container ul,
 .article-container ol {
-    @apply text-gray-800;
+    @apply text-ne-on-background;
 }
 
 .article-container table {
-    @apply bg-white border-gray-400;
+    @apply bg-white border-ne-surface;
 }
 
 .article-container tbody tr:nth-child(even) {
-    @apply bg-gray-100;
+    @apply bg-ne-surface;
 }
 .article-container tbody tr:hover {
-    @apply bg-gray-300;
+    @apply bg-ne-primary-lighter;
 }
 
 .article-container figcaption {
-    @apply text-gray-700;
+    @apply text-ne-on-surface;
 }
 
 .article-container .alert-warning {
-    @apply text-red-600 bg-red-100;
+    @apply text-ne-on-error bg-ne-error;
 }
 
 section.footnotes:before {
-    @apply text-gray-500 bg-white;
+    @apply text-ne-on-surface-lighter bg-white;
 }
 
 /* TOC and search screen */
 #toc-list ol {
-    @apply text-gray-800 border-gray-300;
+    @apply text-ne-on-background border-ne-surface;
 }
 
 #toc-list a:hover {
-    @apply bg-gray-300;
+    @apply bg-ne-surface;
 }
 
 #toc-container {
@@ -75,7 +75,7 @@ section.footnotes:before {
 }
 
 #toc-top-divider::after {
-    @apply text-gray-500 bg-white;
+    @apply text-ne-on-surface bg-white;
 }
 
 #toc-background-mask,
@@ -87,34 +87,34 @@ section.footnotes:before {
     @apply bg-white shadow-md;
 }
 #search-input {
-    @apply border-b border-gray-300;
+    @apply border-b border-ne-surface;
 }
 #search-input input {
-    @apply text-gray-700;
+    @apply text-ne-surface-dark;
 }
 
 ul.search-results {
-    @apply text-gray-700;
+    @apply text-ne-surface-dark;
 }
 
 ul.search-results li {
-    @apply border-gray-300;
+    @apply border-ne-surface;
 }
 
 ul.search-results li:hover {
-    @apply bg-gray-200;
+    @apply bg-ne-surface;
 }
 
 .search-results .search-res-title {
-    @apply text-gray-800;
+    @apply text-ne-on-background;
 }
 
 .search-results .search-res-date {
-    @apply text-gray-500;
+    @apply text-ne-on-surface-lighter;
 }
 
 .search-results .search-res-content {
-    @apply text-gray-700;
+    @apply text-ne-surface-dark;
 }
 
 /* Unified buttons style */
@@ -124,60 +124,60 @@ ul.search-results li:hover {
 
 .round-button button,
 button.round-button {
-    @apply font-bold text-gray-800;
+    @apply font-bold text-ne-on-background;
 }
 
 /* Site header */
 #site-header {
-    @apply bg-white text-gray-700 text-lg shadow-sm;
+    @apply bg-white text-ne-surface-dark text-lg shadow-sm;
 }
 
 .site-header-navlink:hover {
-    @apply bg-gray-300;
+    @apply bg-ne-surface;
 }
 
 /* Styling cards and elements */
 .post-card {
-    @apply bg-white text-gray-700;
+    @apply bg-white text-ne-surface-dark;
 }
 
 .gray-tag {
-    @apply text-gray-700 bg-gray-200;
+    @apply text-ne-surface-dark bg-ne-surface;
 }
 
 .post-footer {
-    @apply text-gray-700;
+    @apply text-ne-surface-dark;
 }
 
 .post-summary {
-    @apply text-gray-600;
+    @apply text-ne-on-surface;
 }
 
 /* Publication related */
 #publication-metadata {
-    @apply text-gray-600;
+    @apply text-ne-on-surface;
 }
 
 .listview-wrapper {
-    @apply text-gray-700;
+    @apply text-ne-surface-dark;
 }
 
 .listview-row:hover {
-    @apply bg-gray-200;
+    @apply bg-ne-surface;
 }
 
 /* Homepage pagination */
 ul.pagination {
-    @apply border-gray-200;
+    @apply border-ne-surface;
 }
 
 li.page-item {
-    @apply border-gray-200 text-gray-600;
+    @apply border-ne-surface text-ne-on-surface;
 }
 
 li.page-item.active {
-    @apply text-gray-700 border-yellow-400;
+    @apply text-ne-on-background border-ne-secondary;
 }
 li.page-item.disabled {
-    @apply text-gray-400;
+    @apply text-ne-on-surface-lighter;
 }

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -326,3 +326,17 @@ iframe.instagram-media,
 .twitter-tweet {
     @apply mx-auto !important;
 }
+
+/* Unified buttons style */
+.round-button {
+    @apply rounded-full transition-all duration-150 ease-linear  hover:bg-ne-primary-dark;
+}
+
+.round-button button,
+button.round-button {
+    @apply font-bold;
+}
+
+.social-button {
+    @apply h-8 w-8 flex items-center justify-center bg-ne-surface-darker hover:bg-ne-primary-dark text-white hover:text-ne-on-primary !important;
+}

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -128,7 +128,7 @@ article {
 
 /* Text elements */
 .article-container a {
-    @apply underline hover:text-ne-primary-dark;
+    @apply underline hover:text-ne-primary-darker;
 }
 
 .article-container p {
@@ -145,7 +145,7 @@ article {
 
 /* Tables */
 .article-container table {
-    @apply block mx-auto my-4 border-ne-surface;
+    @apply block mx-auto my-4;
     @apply overflow-y-hidden overflow-x-auto;
     max-width: fit-content;
 }
@@ -207,7 +207,7 @@ a.footnote-ref::after {
 
 #toc-top-divider::after {
     content: "Table of Contents";
-    @apply inline-block text-ne-on-surface font-bold bg-ne-surface-lighter pr-2 transform -translate-y-4;
+    @apply inline-block font-bold pr-2 transform -translate-y-4;
 }
 
 #toc-list > #TableOfContents > ol {

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -18,10 +18,6 @@ body {
     counter-reset: captions;
 }
 
-body {
-    counter-reset: captions;
-}
-
 /* ################################# */
 /* #         Overall design        # */
 /* ################################# */
@@ -66,21 +62,12 @@ hr {
 
 /* Blockquote */
 blockquote {
-    @apply pl-10 pr-2 py-4 my-2 relative border-l-2;
-}
-
-@media (min-width: 768px) {
-    blockquote {
-        @apply pl-16 ml-4 pr-4;
-    }
+    @apply font-serif pl-10 pr-2 py-4 my-2 relative border-l-2 border-ne-primary-dark md:pl-16 md:ml-4 md:pr-4;
 }
 
 blockquote::before {
-    @apply absolute font-serif text-yellow-400;
-    font-size: 6rem;
+    @apply absolute font-serif text-ne-primary text-8xl left-2 -top-0.5 !important;
     content: "\201C";
-    top: -1.5rem;
-    left: 0.5rem;
 }
 
 /* Code highlight */
@@ -141,10 +128,7 @@ article {
 
 /* Text elements */
 .article-container a {
-    @apply underline;
-}
-.article-container a:hover {
-    @apply bg-yellow-400 text-gray-800;
+    @apply underline hover:text-ne-primary-dark;
 }
 
 .article-container p {
@@ -161,7 +145,7 @@ article {
 
 /* Tables */
 .article-container table {
-    @apply block mx-auto my-4 border-gray-400;
+    @apply block mx-auto my-4 border-ne-surface;
     @apply overflow-y-hidden overflow-x-auto;
     max-width: fit-content;
 }
@@ -223,7 +207,7 @@ a.footnote-ref::after {
 
 #toc-top-divider::after {
     content: "Table of Contents";
-    @apply inline-block text-gray-500 font-bold bg-white pr-2 transform -translate-y-4;
+    @apply inline-block text-ne-on-surface font-bold bg-ne-surface-lighter pr-2 transform -translate-y-4;
 }
 
 #toc-list > #TableOfContents > ol {
@@ -253,9 +237,7 @@ a.footnote-ref::after {
 }
 .toc-hidden,
 .search-hidden {
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 300ms ease-in;
+    @apply opacity-0 invisible transition-opacity duration-300 ease-in;
 }
 
 /* ################################# */
@@ -304,7 +286,7 @@ ul.search-results li {
 }
 
 .post-feat-card-content * {
-    @apply text-gray-200;
+    @apply text-ne-on-background-dark;
 }
 
 .post-card {

--- a/assets/css/tailwind-colors.js
+++ b/assets/css/tailwind-colors.js
@@ -1,57 +1,57 @@
 // DEFAULT colors are for the light theme, and dark colors are for the dark theme.
 // Names adopted from Material Design:
 // https://material.io/design/color/the-color-system.html
+const colors = require("tailwindcss/colors");
 module.exports = {
     // buttons, tags
     primary: {
-        lighter: "#FEF3C7",
-        DEFAULT: "#FDE68A",
-        dark: "#FCD34D",
-        darker: "#FBBF24",
+        lighter: colors.amber[100],
+        DEFAULT: colors.amber[200],
+        dark: colors.amber[300],
+        darker: colors.amber[400],
     },
     // links
     secondary: {
-        lighter: "#93C5FD",
-        DEFAULT: "#2563EB",
-        dark: "#1D4ED8",
-        darker: "#1E3A8A",
+        lighter: colors.blue[300],
+        DEFAULT: colors.blue[600],
+        dark: colors.blue[700],
+        darker: colors.blue[900],
     },
 
     background: {
-        DEFAULT: "#F3F4F6",
-        dark: "#1F2937",
+        DEFAULT: colors.coolGray[100],
+        dark: colors.coolGray[800],
     },
     // cards, menus, header
     surface: {
-        DEFAULT: "#E5E7EB",
-        dark: "#374151",
-        darker: "#1F2937",
+        DEFAULT: colors.coolGray[200],
+        dark: colors.coolGray[600],
+        darker: colors.coolGray[700],
     },
     // in-line code, warning blocks
     error: {
-        lighter: "#FFF1F2",
-        DEFAULT: "#FEE2E2",
-        dark: "#FCA5A5",
-        darker: "#EF4444",
+        lighter: colors.rose[50],
+        DEFAULT: colors.red[100],
+        dark: colors.red[300],
+        darker: colors.red[500],
     },
     // text and icons
     on: {
         primary: {
-            DEFAULT: "#111827",
-            dark: "#111827",
+            DEFAULT: colors.coolGray[900],
         },
         background: {
-            DEFAULT: "#111827",
-            dark: "#F9FAFB",
+            DEFAULT: colors.coolGray[900],
+            dark: colors.coolGray[50],
         },
         surface: {
-            lighter: "#D1D5DB",
-            DEFAULT: "#6B7280",
-            dark: "#9CA3AF",
+            lighter: colors.coolGray[300],
+            DEFAULT: colors.coolGray[500],
+            dark: colors.coolGray[400],
         },
         error: {
-            DEFAULT: "#DC2626",
-            dark: "#B91C1C",
+            DEFAULT: colors.red[600],
+            dark: colors.red[700],
         },
     },
 };

--- a/assets/css/tailwind-colors.js
+++ b/assets/css/tailwind-colors.js
@@ -5,9 +5,9 @@ module.exports = {
     // buttons, tags
     primary: {
         lighter: "#FEF3C7",
-        DEFAULT: "#FCD34D",
-        dark: "#FBBF24",
-        darker: "#F59E0B",
+        DEFAULT: "#FDE68A",
+        dark: "#FCD34D",
+        darker: "#FBBF24",
     },
     // links
     secondary: {
@@ -24,8 +24,8 @@ module.exports = {
     },
     // cards, menus, header
     surface: {
-        lighter: "#F9FAFB",
-        DEFAULT: "#FFFFFF",
+        lighter: "#FFFFFF",
+        DEFAULT: "#E5E7EB",
         dark: "#374151",
         darker: "#1F2937",
     },
@@ -44,10 +44,10 @@ module.exports = {
         },
         background: {
             DEFAULT: "#111827",
-            dark: "#E5E7EB",
+            dark: "#F9FAFB",
         },
         surface: {
-            DEFAULT: "#4B5563",
+            DEFAULT: "#6B7280",
             dark: "#9CA3AF",
         },
         error: {

--- a/assets/css/tailwind-colors.js
+++ b/assets/css/tailwind-colors.js
@@ -1,0 +1,58 @@
+// DEFAULT colors are for the light theme, and dark colors are for the dark theme.
+// Names adopted from Material Design:
+// https://material.io/design/color/the-color-system.html
+module.exports = {
+    // buttons, tags
+    primary: {
+        lighter: "#FEF3C7",
+        DEFAULT: "#FCD34D",
+        dark: "#FBBF24",
+        darker: "#F59E0B",
+    },
+    // links
+    secondary: {
+        lighter: "#93C5FD",
+        DEFAULT: "#3B82F6",
+        dark: "#1D4ED8",
+        darker: "#1E3A8A",
+    },
+
+    background: {
+        lighter: "#FFFFFF",
+        DEFAULT: "#F3F4F6",
+        dark: "#1F2937",
+    },
+    // cards, menus, header
+    surface: {
+        lighter: "#F9FAFB",
+        DEFAULT: "#FFFFFF",
+        dark: "#374151",
+        darker: "#1F2937",
+    },
+    // in-line code, warning blocks
+    error: {
+        lighter: "#FFF1F2",
+        DEFAULT: "#FEE2E2",
+        dark: "#FCA5A5",
+        darker: "#EF4444",
+    },
+    // text and icons
+    on: {
+        primary: {
+            DEFAULT: "#111827",
+            dark: "#111827",
+        },
+        background: {
+            DEFAULT: "#111827",
+            dark: "#E5E7EB",
+        },
+        surface: {
+            DEFAULT: "#4B5563",
+            dark: "#9CA3AF",
+        },
+        error: {
+            DEFAULT: "#DC2626",
+            dark: "#B91C1C",
+        },
+    },
+};

--- a/assets/css/tailwind-colors.js
+++ b/assets/css/tailwind-colors.js
@@ -12,21 +12,20 @@ module.exports = {
     },
     // links
     secondary: {
-        lighter: colors.blue[300],
-        DEFAULT: colors.blue[600],
-        dark: colors.blue[700],
-        darker: colors.blue[900],
+        lighter: colors.blue[100],
+        DEFAULT: colors.blue[700],
+        dark: colors.blue[400],
     },
 
     background: {
         DEFAULT: colors.coolGray[100],
-        dark: colors.coolGray[800],
+        dark: colors.coolGray[900],
     },
     // cards, menus, header
     surface: {
         DEFAULT: colors.coolGray[200],
-        dark: colors.coolGray[600],
-        darker: colors.coolGray[700],
+        dark: colors.coolGray[700],
+        darker: colors.coolGray[800],
     },
     // in-line code, warning blocks
     error: {
@@ -42,7 +41,7 @@ module.exports = {
         },
         background: {
             DEFAULT: colors.coolGray[900],
-            dark: colors.coolGray[50],
+            dark: colors.coolGray[200],
         },
         surface: {
             lighter: colors.coolGray[300],
@@ -51,7 +50,7 @@ module.exports = {
         },
         error: {
             DEFAULT: colors.red[600],
-            dark: colors.red[700],
+            dark: colors.red[800],
         },
     },
 };

--- a/assets/css/tailwind-colors.js
+++ b/assets/css/tailwind-colors.js
@@ -12,19 +12,17 @@ module.exports = {
     // links
     secondary: {
         lighter: "#93C5FD",
-        DEFAULT: "#3B82F6",
+        DEFAULT: "#2563EB",
         dark: "#1D4ED8",
         darker: "#1E3A8A",
     },
 
     background: {
-        lighter: "#FFFFFF",
         DEFAULT: "#F3F4F6",
         dark: "#1F2937",
     },
     // cards, menus, header
     surface: {
-        lighter: "#FFFFFF",
         DEFAULT: "#E5E7EB",
         dark: "#374151",
         darker: "#1F2937",
@@ -47,6 +45,7 @@ module.exports = {
             dark: "#F9FAFB",
         },
         surface: {
+            lighter: "#D1D5DB",
             DEFAULT: "#6B7280",
             dark: "#9CA3AF",
         },

--- a/assets/css/tailwind-dev.config.js
+++ b/assets/css/tailwind-dev.config.js
@@ -1,6 +1,7 @@
-const themeDir = __dirname + "/../../";
 const defaultTheme = require("tailwindcss/defaultTheme");
+const neColors = require("./tailwind-colors"); // ne stands for northeast;
 module.exports = {
+    // doesn't really work because for the dark theme two css files are used
     darkMode: "media",
     theme: {
         extend: {
@@ -8,6 +9,9 @@ module.exports = {
                 sans: ['"Open Sans"', ...defaultTheme.fontFamily.sans],
                 serif: ['"PT Serif"', ...defaultTheme.fontFamily.serif],
                 mono: ['"JetBrains Mono"', ...defaultTheme.fontFamily.mono],
+            },
+            colors: {
+                ne: neColors,
             },
         },
     },

--- a/assets/css/tailwind-dev.config.js
+++ b/assets/css/tailwind-dev.config.js
@@ -1,17 +1,13 @@
 const themeDir = __dirname + "/../../";
 const defaultTheme = require("tailwindcss/defaultTheme");
 module.exports = {
-    important: true,
+    darkMode: "media",
     theme: {
         extend: {
             fontFamily: {
                 sans: ['"Open Sans"', ...defaultTheme.fontFamily.sans],
                 serif: ['"PT Serif"', ...defaultTheme.fontFamily.serif],
                 mono: ['"JetBrains Mono"', ...defaultTheme.fontFamily.mono],
-            },
-            screens: {
-                dark: { raw: "(prefers-color-scheme: dark)" },
-                // => @media (prefers-color-scheme: dark) { ... }
             },
         },
     },

--- a/assets/css/tailwind-dev.config.js
+++ b/assets/css/tailwind-dev.config.js
@@ -1,8 +1,6 @@
 const defaultTheme = require("tailwindcss/defaultTheme");
 const neColors = require("./tailwind-colors"); // ne stands for northeast;
 module.exports = {
-    // doesn't really work because for the dark theme two css files are used
-    darkMode: "media",
     theme: {
         extend: {
             fontFamily: {

--- a/assets/css/tailwind.config.js
+++ b/assets/css/tailwind.config.js
@@ -1,5 +1,6 @@
 const themeDir = __dirname + "/../../";
 const defaultTheme = require("tailwindcss/defaultTheme");
+const neColors = require("./tailwind-colors"); // ne stands for northeast;
 module.exports = {
     purge: {
         enabled: true,
@@ -19,6 +20,9 @@ module.exports = {
                 sans: ['"Open Sans"', ...defaultTheme.fontFamily.sans],
                 serif: ['"PT Serif"', ...defaultTheme.fontFamily.serif],
                 mono: ['"JetBrains Mono"', ...defaultTheme.fontFamily.mono],
+            },
+            colors: {
+                ne: neColors,
             },
         },
     },

--- a/assets/css/tailwind.config.js
+++ b/assets/css/tailwind.config.js
@@ -1,11 +1,6 @@
 const themeDir = __dirname + "/../../";
 const defaultTheme = require("tailwindcss/defaultTheme");
 module.exports = {
-    future: {
-        removeDeprecatedGapUtilities: true,
-        purgeLayersByDefault: true,
-    },
-    important: true,
     purge: {
         enabled: true,
         content: [
@@ -17,16 +12,13 @@ module.exports = {
             "exampleSite/content/**/*.html",
         ],
     },
+    darkMode: "media",
     theme: {
         extend: {
             fontFamily: {
                 sans: ['"Open Sans"', ...defaultTheme.fontFamily.sans],
                 serif: ['"PT Serif"', ...defaultTheme.fontFamily.serif],
                 mono: ['"JetBrains Mono"', ...defaultTheme.fontFamily.mono],
-            },
-            screens: {
-                dark: { raw: "(prefers-color-scheme: dark)" },
-                // => @media (prefers-color-scheme: dark) { ... }
             },
         },
     },

--- a/assets/css/tailwind.config.js
+++ b/assets/css/tailwind.config.js
@@ -13,7 +13,6 @@ module.exports = {
             "exampleSite/content/**/*.html",
         ],
     },
-    darkMode: "media",
     theme: {
         extend: {
             fontFamily: {

--- a/assets/js/minisearch-config.js
+++ b/assets/js/minisearch-config.js
@@ -143,7 +143,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                 let ans = markMatches(hit);
                                 ans.date = timestamp2Date(hit.date);
                                 let star = feather.icons.star.toSvg({
-                                    class: "inline-block mb-1 text-yellow-400",
+                                    class: "inline-block mb-1 text-ne-primary",
                                     width: 16,
                                     height: 16,
                                     fill: "#f6e05e",

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<h2 class="text-center text-gray-500">{{if (eq .Type "tags") }}#{{ end }}{{ .Title }}</h2>
+<h2 class="text-center text-ne-on-surface">{{if (eq .Type "tags") }}#{{ end }}{{ .Title }}</h2>
 <div class="listview-wrapper flex flex-col space-y-1 text-xl max-w-4xl mx-auto">
     {{ range .Pages.GroupByDate "2006" }}
     <div class="font-sans text-2xl mt-4 mb-2">{{ .Key }}</div>
@@ -17,9 +17,9 @@
                     {{- .Title -}}
                 </div>
 
-                <div class="flex flex-row flex-shrink-0 items-center text-gray-500 font-semibold tracking-tighter text-sm">
+                <div class="flex flex-row flex-shrink-0 items-center text-ne-on-surface font-semibold tracking-tighter text-sm">
                     {{ if .Params.featured }}
-                    <i data-feather="star" class="inline-block mr-1 text-sm text-yellow-400 w-4 h-4" fill="#f6e05e"></i>
+                    <i data-feather="star" class="inline-block mr-1 text-sm w-4 h-4 text-ne-primary-dark" fill="#FCD34D"></i>
                     {{ end }}
                     {{- dateFormat "Jan 02" .PublishDate -}}
                 </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,7 @@
     {{/* Post tags, title, metadata and banner image */}}
     <div class="py-2">
         {{ partial "post-tags" . }}
-        <h1 class="text-center py-2 px-6">{{ .Title }}</h1>
+        <h1 class="text-center pt-2 pb-6 px-6">{{ .Title }}</h1>
         {{ partial "post-metadata" . }}
         <div class="my-8 rounded overflow-hidden">
             {{ .Scratch.Set "set_img_link" true }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
     {{/* Carousel of featured posts */}}
     <div class="glide w-full rounded-md overflow-hidden max-w-5xl" style="height: 30rem;">
         <div class="glide__track h-full" data-glide-el="track">
-            <div class="glide__slides h-full flex flex-row flex-no-wrap">
+            <div class="glide__slides h-full flex flex-row flex-nowrap">
                 {{ range first 7 (where site.RegularPages.ByPublishDate.Reverse "Params.featured" true) }}
                 <div class="glide__slide flex flex-shrink-0 overflow-hidden">
                     {{ .Scratch.Set "feat_card_controls" true }}

--- a/layouts/partials/back-to-top-button.html
+++ b/layouts/partials/back-to-top-button.html
@@ -1,4 +1,4 @@
-<a href="#" class="round-button hover:bg-yellow-400 block w-8 h-8 my-2">
+<a href="#" class="round-button block w-8 h-8 my-2">
     <button class="w-8 h-8 focus:outline-none" aria-label="Back to Top">
         <i data-feather="chevron-up" class="mx-auto"></i>
     </button>

--- a/layouts/partials/dev-parameters.html
+++ b/layouts/partials/dev-parameters.html
@@ -1,9 +1,9 @@
 {{ if .Site.IsServer }}
-<div class="h-64 mb-4 py-4 px-4 overflow-y-auto scrolling-touch border-t border-gray-200">
-    <table class="w-full text-left table-auto table-collapse border-gray-200 dark:text-gray-300">
+<div class="h-64 mb-4 py-4 px-4 overflow-y-auto scrolling-touch border-t border-ne-surface">
+    <table class="w-full text-left table-auto table-collapse border-ne-surface text-ne-on-surface-dark">
         <caption class="text-left pb-2">Hugo Variables for the current page.</caption>
         <thead>
-            <tr class="p-2 font-semibold bg-gray-100 border-t ">
+            <tr class="p-2 font-semibold bg-ne-surface border-t ">
                 <th>Variable</th>
                 <th>Value</th>
             </tr>

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -1,14 +1,14 @@
-<footer class="w-full h-32 text-center px-4 pb-4 pt-8 inset-0 text-sm text-gray-200 bg-gray-800 border-t border-gray-300">
+<footer class="w-full h-32 text-center px-4 pb-4 pt-8 inset-0 text-sm bg-ne-surface-darker">
     {{ partial "social-list" }}
-    <p class="text-gray-500">
+    <p class="text-ne-on-surface">
         {{ with site.Copyright }} {{- replace . "{year}" now.Year | markdownify -}} {{ end }}
-        <a href="{{- site.BaseURL -}}" class="text-gray-200 hover:underline">{{- site.Title -}}</a>
+        <a href="{{- site.BaseURL -}}" class="text-ne-on-background-dark hover:text-ne-primary-dark">{{- site.Title -}}</a>
         &copy; Powered by the
         <a href="https://github.com/y1zhou/hugo-northeast" target="_blank" rel="noopener"
-            class="text-gray-200 hover:underline">
+            class="text-ne-on-background-dark hover:text-ne-primary-dark">
             Northeast theme</a>
         for
-        <a href="https://gohugo.io" class="text-gray-200 hover:underline">
+        <a href="https://gohugo.io" class="text-ne-on-background-dark hover:text-ne-primary-dark">
             Hugo</a>.
     </p>
 </footer>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,4 @@
-<header id="site-header" class="relative md:flex md:items-center">
+<header id="site-header" class="relative text-lg md:flex md:items-center">
     {{/* Single row on large screens; two rows on mobile */}}
     <div class="block relative mx-auto md:flex md:flex-grow md:max-w-screen-lg md:px-3">
         {{/* Logo and site title */}}

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -10,14 +10,14 @@
 
         {{/* featured */}}
         {{ if .Params.featured }}
-        <i data-feather="star" class="absolute right-0 top-0 pr-4 pt-4 w-10 h-10 text-yellow-400" fill="#f6e05e"></i>
+        <i data-feather="star" class="absolute right-0 top-0 pr-4 pt-4 w-10 h-10 text-ne-primary-dark" fill="#FCD34D"></i>
         {{ end }}
 
         <div class="px-2 sm:px-4">
             <div class="flex flex-row flex-wrap justify-between content-center tracking-tighter mt-2">
                 {{/* Page categories */}}
                 {{ if .Params.categories }}
-                <div class="flex flex-shrink font-serif text-gray-600 pr-2">
+                <div class="flex flex-shrink font-serif text-ne-on-surface pr-2">
                     {{- range $index, $value := (.GetTerms "categories") -}}
                     {{- if gt $index 0 }} | {{ end -}}
                     {{- humanize .LinkTitle -}}
@@ -26,7 +26,7 @@
                 {{ end }}
 
                 {{/* Date and category */}}
-                <div class="flex flex-row justify-start items-center space-x-2 text-gray-500 text-sm divide-x-2">
+                <div class="flex flex-row justify-start items-center space-x-2 text-ne-on-surface text-sm divide-x-2">
                     {{ with .PublishDate }}
                     <div class="flex flex-shrink-0 items-center">
                         {{ dateFormat "Jan 2, 2006" .Local -}}
@@ -53,7 +53,7 @@
     <div class="flex flex-wrap justify-left px-2 sm:px-4 my-2 space-x-2">
         {{ range (.GetTerms "tags") }}
         <a href="{{ .Permalink }}"
-            class="gray-tag inline-block px-3 py-1 my-1 rounded-full hover:bg-yellow-400 text-sm no-underline tracking-tight leading-tight font-semibold">
+            class="gray-tag inline-block px-3 py-1 my-1 rounded-full text-sm no-underline tracking-tight leading-tight font-semibold">
             #{{ .LinkTitle }}
         </a>
         {{ end }}

--- a/layouts/partials/post-featured-card.html
+++ b/layouts/partials/post-featured-card.html
@@ -20,7 +20,7 @@
 
         {{/* Page categories */}}
         {{ if .Params.categories }}
-        <div class="absolute top-0 text-gray-200 font-bold tracking-tight w-4/5 pl-4 sm:pl-8 pt-10 sm:pt-32">
+        <div class="absolute top-0 text-ne-on-background-dark font-bold tracking-tight w-4/5 pl-4 sm:pl-8 pt-10 sm:pt-32">
             <i data-feather="bookmark" class=" inline-block mr-1 w-4 h-4"></i>
             {{- range $index, $value := (.GetTerms "categories") -}}
             {{- if gt $index 0 }} | {{ end -}}
@@ -33,14 +33,14 @@
         <h2 class="absolute top-0 text-white w-4/5 pl-4 sm:pl-8 pt-20 sm:pt-40">{{ .Title }}</h2>
 
         {{ if (.Scratch.Get "feat_card_content" | default false) }}
-        <div class="post-feat-card-content absolute top-0 text-gray-200 w-11/12 pl-4 sm:pl-8 pt-48 sm:pt-56">
+        <div class="post-feat-card-content absolute top-0 text-ne-on-background-dark w-11/12 pl-4 sm:pl-8 pt-48 sm:pt-56">
             {{ .Content }}
         </div>
         {{ end }}
 
         {{/* Page publish date and reading time */}}
         {{ if (.Scratch.Get "feat_card_metadata" | default true) }}
-        <div class="absolute bottom-0 text-gray-200 font-bold tracking-tight pl-4 sm:pl-8 pb-4">
+        <div class="absolute bottom-0 text-ne-on-background-dark font-bold tracking-tight pl-4 sm:pl-8 pb-4">
             {{ with .PublishDate }}
             {{- dateFormat "Jan 2, 2006" .Local }} |
             {{ end }}

--- a/layouts/partials/post-featured-image.html
+++ b/layouts/partials/post-featured-image.html
@@ -85,7 +85,7 @@ directory as the post. Alternatively, you can use a photo ID from Unsplash. */}}
 
 {{ if (.Scratch.Get "set_img_caption") }}
     {{ with .Params.header_image.caption }}
-    <div class="absolute bottom-0 right-0 text-gray-300 bg-gray-900 bg-opacity-50 px-2">
+    <div class="absolute bottom-0 right-0 text-ne-on-background-dark bg-ne-background-dark bg-opacity-50 px-2">
         {{ . | markdownify | emojify }}
     </div>
     {{ end }}

--- a/layouts/partials/post-metadata.html
+++ b/layouts/partials/post-metadata.html
@@ -1,5 +1,5 @@
 <div
-    class="flex flex-row overflow-y-hidden overflow-x-auto w-full justify-start md:justify-center items-center space-x-4 text-gray-500 text-sm font-bold divide-x-2 ">
+    class="flex flex-row overflow-y-hidden overflow-x-auto w-full justify-start md:justify-center items-center space-x-4 text-ne-on-surface text-sm font-bold divide-x-2 ">
     {{ with .PublishDate }}
     <div class="flex flex-shrink-0 items-center">
         <i data-feather="calendar" class="mr-1 w-4 h-4"></i>

--- a/layouts/partials/post-prev-next.html
+++ b/layouts/partials/post-prev-next.html
@@ -2,12 +2,12 @@
     <div class="flex-initial order-first text-left justify-start" style="max-width: 50%;">
         {{/* prev/next labels are reversed in Hugo */}}
         {{with .NextInSection}}
-        <a href="{{ .Permalink }}" class="post-footer flex flex-row items-center justify-center px-2 hover:bg-gray-300">
-            <div class="mr-4 order-first text-gray-500">
+        <a href="{{ .Permalink }}" class="post-footer listview-row flex flex-row items-center justify-center px-2">
+            <div class="mr-4 order-first">
                 <i data-feather="chevron-left" class="w-6 h-6"></i>
             </div>
             <div class="order-last">
-                <div class="text-gray-500 font-bold text-base">Previous</div>
+                <div class="font-bold text-base">Previous</div>
                 <div class="font-serif transition-none">
                     {{ .Title }}
                 </div>
@@ -17,12 +17,12 @@
     </div>
     <div class="flex-initial order-last text-right justify-end" style="max-width: 50%;">
         {{with .PrevInSection}}
-        <a href="{{ .Permalink }}" class="post-footer flex flex-row items-center justify-center px-2 hover:bg-gray-300">
-            <div class="ml-4 order-last text-gray-500">
+        <a href="{{ .Permalink }}" class="post-footer listview-row flex flex-row items-center justify-center px-2">
+            <div class="ml-4 order-last">
                 <i data-feather="chevron-right" class="w-6 h-6"></i>
             </div>
             <div class="order-first">
-                <div class="text-gray-500 font-bold text-base">Next</div>
+                <div class="font-bold text-base">Next</div>
                 <div class="font-serif transition-none">
                     {{ .Title }}
                 </div>

--- a/layouts/partials/post-suggestions.html
+++ b/layouts/partials/post-suggestions.html
@@ -1,24 +1,24 @@
 {{ $related := site.RegularPages.Related . | first 5 }}
 {{ with $related }}
-<div class="text-gray-500 font-bold text-base mb-2">
+<div class="text-ne-on-surface font-bold text-base mb-2">
     Related Posts
 </div>
 
 <table class="table-fixed text-lg leading-loose w-full mx-auto">
     <tbody class="post-footer">
         {{ range . }}
-        <tr class="hover:bg-gray-300 cursor-pointer" onclick="window.location = {{ .Permalink }}">
+        <tr class="listview-row cursor-pointer" onclick="window.location = {{ .Permalink }}">
             <td class="pl-1 lg:pl-4 w-16 lg:w-20 font-semibold tracking-tighter text-sm">
                 {{- dateFormat "Jan 02" .PublishDate -}}
             </td>
             <td class="px-2 font-serif truncate">
-                <a href="{{ .Permalink }}" class="hover:bg-transparent transition-none">
+                <a href="{{ .Permalink }}" class="hover:bg-transparent">
                     {{- .Title -}}
                 </a>
             </td>
-            <td class="pr-1 lg:pr-4 w-24 lg:w-32 text-sm text-gray-600 tracking-tighter text-right">
+            <td class="pr-1 lg:pr-4 w-24 lg:w-32 text-sm tracking-tighter text-right">
                 {{ if .Params.featured }}
-                <i data-feather="star" class="inline-block text-yellow-400 pr-1 w-5 h-5" fill="#f6e05e"></i>
+                <i data-feather="star" class="inline-block text-ne-primary-dark pr-1 w-5 h-5" fill="#FCD34D"></i>
                 {{ end }} {{- .ReadingTime }} min read
             </td>
         </tr>

--- a/layouts/partials/post-tags.html
+++ b/layouts/partials/post-tags.html
@@ -1,11 +1,11 @@
 <div class="flex flex-wrap justify-center space-x-2">
     {{ range (.GetTerms "tags") }}
     <span
-        class="inline-block bg-yellow-400 hover:bg-yellow-500 px-3 py-0 my-1 rounded-full"
+        class="inline-block bg-ne-primary-dark hover:bg-ne-primary-darker px-3 py-0 my-1 rounded-full"
     >
         <a
             href="{{ .Permalink }}"
-            class="text-gray-700 text-sm no-underline hover:bg-transparent tracking-tight font-semibold"
+            class="text-ne-on-primary text-sm no-underline hover:bg-transparent tracking-tight font-semibold"
         >
             #{{ .LinkTitle }}</a
         >

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -3,7 +3,7 @@
         class="w-11/12 md:w-3/5 max-w-2xl mt-24 mx-auto rounded-md overflow-hidden transform -translate-y-4 transition-transform duration-150 ease-in">
         {{/* Search input */}}
         <div class="relative">
-            <div id="search-input" class="rounded-md text-gray-500">
+            <div id="search-input" class="rounded-md">
                 <input
                     class="pl-8 pr-6 py-2 block w-full focus:outline-none"
                     type="text" placeholder="Search..." />
@@ -15,14 +15,14 @@
 
         {{/* Popular tags */}}
         <div id="search-popular-tags" class="block px-4 py-2">
-            <div class="w-full text-gray-500 text-base tracking-tight font-semibold">
+            <div class="w-full text-ne-on-surface text-base tracking-tight font-semibold">
                 Popular Tags
             </div>
             <div
                 class="flex flex-row flex-wrap justify-start space-x-2 text-sm font-semibold">
                 {{ range first 5 site.Taxonomies.tags.ByCount }}
                 <a href="/tags/{{ .Name }}"
-                    class="gray-tag my-1 hover:bg-yellow-400 px-3 py-0 rounded-full">#{{- .Name -}}</a>
+                    class="gray-tag my-1 px-3 py-0 rounded-full">#{{- .Name -}}</a>
                 {{ end }}
             </div>
         </div>

--- a/layouts/partials/social-list.html
+++ b/layouts/partials/social-list.html
@@ -1,16 +1,16 @@
 <div class="flex justify-center w-full max-w-screen-lg mx-auto mb-2">
-    <ul class="flex flex-row justify-center text-lg space-x-2 max-w-md text-gray-200">
+    <ul class="flex flex-row justify-center text-lg space-x-2 max-w-md">
         {{ with site.Params.email }}
         <li>
             <a href="mailto:{{ . }}" aria-label="email"
-                class="bg-gray-800 hover:bg-yellow-400 hover:text-gray-800 rounded-full h-8 w-8 flex items-center justify-center">
+                class="round-button social-button">
                 <i data-feather="mail" class="w-5 h-5"></i>
             </a>
         </li>
         {{ end }} {{ with site.Params.github }}
         <li>
             <a href="https://github.com/{{ . }}" target="_blank" rel="noopener" aria-label="GitHub"
-                class="bg-gray-800 hover:bg-yellow-400 hover:text-gray-800 rounded-full h-8 w-8 flex items-center justify-center">
+                class="round-button social-button">
                 <i data-feather="github" class="w-5 h-5"></i>
             </a>
         </li>
@@ -18,28 +18,28 @@
         <li>
             <a href="https://scholar.google.com/citations?user={{ . }}" target="_blank" rel="noopener"
                 aria-label="Google Scholar"
-                class="bg-gray-800 hover:bg-yellow-400 hover:text-gray-800 rounded-full h-8 w-8 flex items-center justify-center">
+                class="round-button social-button">
                 <i data-feather="book" class="w-5 h-5"></i>
             </a>
         </li>
         {{ end }} {{ with site.Params.linkedin }}
         <li>
             <a href="https://www.linkedin.com/in/{{ . }}/" target="_blank" rel="noopener" aria-label="LinkedIn"
-                class="bg-gray-800 hover:bg-yellow-400 hover:text-gray-800 rounded-full h-8 w-8 flex items-center justify-center">
+                class="round-button social-button">
                 <i data-feather="linkedin" class="w-5 h-5"></i>
             </a>
         </li>
         {{ end }} {{ with site.Params.twitter }}
         <li>
             <a href="https://twitter.com/{{ . }}" target="_blank" rel="noopener" aria-label="Twitter"
-                class="bg-gray-800 hover:bg-yellow-400 hover:text-gray-800 rounded-full h-8 w-8 flex items-center justify-center">
+                class="round-button social-button">
                 <i data-feather="twitter" class="w-5 h-5"></i>
             </a>
         </li>
         {{ end }}
         <li>
             <a href="/index.xml" aria-label="RSS"
-                class="bg-gray-800 hover:bg-yellow-400 hover:text-gray-800 rounded-full h-8 w-8 flex items-center justify-center">
+                class="round-button social-button">
                 <i data-feather="rss" class="w-5 h-5"></i>
             </a>
         </li>

--- a/layouts/partials/table-of-contents.html
+++ b/layouts/partials/table-of-contents.html
@@ -9,7 +9,7 @@
         class="fixed inset-y-0 right-0 rounded overflow-auto m-2 p-6 sm:m-3 sm:left-auto transform translate-x-full transition-transform duration-300 ease-out">
         <div
             id="toc-top-divider"
-            class="block relative border-t-2 border-gray-300 mt-2 mb-0 transform translate-y-3"
+            class="block relative border-t-2 mt-2 mb-0 transform translate-y-3"
         ></div>
 
         <div id="toc-list">

--- a/layouts/partials/toc-button.html
+++ b/layouts/partials/toc-button.html
@@ -1,6 +1,6 @@
 {{ if and (gt .WordCount 400 ) (.Params.toc) }}
 <button id="toc-button" aria-label="Table of Contents"
-    class="round-button block my-2 hover:bg-yellow-400 focus:outline-none w-8 h-8">
+    class="round-button block my-2 focus:outline-none w-8 h-8">
     <i data-feather="align-left" class="w-5 h-5 mx-auto"></i>
 </button>
 {{ end }}

--- a/layouts/publications/single.html
+++ b/layouts/publications/single.html
@@ -23,19 +23,19 @@
     <div class="flex flex-row justify-center items-center space-x-2">
       {{ with .Params.doi }}
       <a href="https://doi.org/{{ . }}" alt="DOI" title="DOI"
-        class="round-button hover:bg-yellow-400 h-8 w-8 flex items-center justify-center">
+        class="round-button h-8 w-8 flex items-center justify-center">
         <i data-feather="link" class="w-5 h-5"></i>
       </a>
       {{ end }}
       {{ with .Params.pdf_url }}
       <a href="{{ . }}" alt="PDF" title="PDF"
-        class="round-button hover:bg-yellow-400 h-8 w-8 flex items-center justify-center">
+        class="round-button h-8 w-8 flex items-center justify-center">
         <i data-feather="file-text" class="w-5 h-5"></i>
       </a>
       {{ end }}
       {{ with .Params.cite_url }}
       <a href="{{ . }}" alt="Cite" title="Cite"
-        class="round-button hover:bg-yellow-400 h-8 w-8 flex items-center justify-center">
+        class="round-button h-8 w-8 flex items-center justify-center">
         <i data-feather="paperclip" class="w-5 h-5"></i>
       </a>
       {{ end }}

--- a/layouts/section/posts.html
+++ b/layouts/section/posts.html
@@ -1,12 +1,12 @@
 {{ define "main" }}
-<h2 class="text-center text-gray-500">{{ .Title }}</h2>
+<h2 class="text-center text-ne-on-surface">{{ .Title }}</h2>
 <div class="flex flex-col space-y-1 text-xl listview-wrapper max-w-6xl mx-auto">
     {{ range .Pages.GroupByDate "2006" }}
     <div class="font-sans text-2xl mt-4 mb-2">{{ .Key }}</div>
     {{ range .Pages.ByPublishDate.Reverse }}
         <a href="{{ .Permalink }}" class="hover:bg-transparent">
             <div class="flex flex-row items-center justify-start py-1 px-1 listview-row">
-                <div class="flex flex-row flex-shrink-0 items-center text-gray-500 font-semibold tracking-tighter text-sm">
+                <div class="flex flex-row flex-shrink-0 items-center text-ne-on-surface font-semibold tracking-tighter text-sm">
                     {{- dateFormat "Jan 02" .PublishDate -}}
                 </div>
 
@@ -15,7 +15,7 @@
                 </div>
 
                 {{ if .Params.featured }}
-                    <i data-feather="star" class="inline-block mr-1 text-sm text-yellow-400 w-5 h-5" fill="#f6e05e"></i>
+                    <i data-feather="star" class="inline-block mr-1 text-sm text-ne-primary-dark w-5 h-5" fill="#FCD34D"></i>
                 {{ end }}
             </div>
         </a>

--- a/layouts/section/publications.html
+++ b/layouts/section/publications.html
@@ -6,12 +6,12 @@
     <div class="font-sans text-2xl mt-4 mb-2">{{ .Key }}</div>
     {{ range .Pages.ByDate.Reverse }}
     <div class="flex flex-row items-center justify-start py-1 px-1">
-        <div class="flex flex-row flex-shrink-0 items-center text-gray-500 font-semibold tracking-tighter text-sm">
+        <div class="flex flex-row flex-shrink-0 items-center text-ne-on-surface font-semibold tracking-tighter text-sm">
             {{- dateFormat "Jan 02" .Date -}}
         </div>
 
         <div class="flex flex-row flex-grow flex-wrap items-center font-serif pl-4">
-            <p class="listview-row">
+            <p>
                 {{ with .Params.authors }}
                 {{ range $i, $author := . }}
                     {{- if gt $i 0 -}}, {{ end -}}
@@ -19,8 +19,8 @@
                 {{- end -}}
                 <span>.</span>
                 {{ end }}
-                
-                <a href="{{ .Permalink }}" class="text-blue-500 hover:bg-transparent hover:underline">{{ .Title }}.</a>
+
+                <a href="{{ .Permalink }}" class="text-ne-secondary-dark hover:text-ne-primary-darker">{{ .Title }}.</a>
 
                 {{ with .Params.journal }}<span class="italic">{{ . }}</span>{{ end -}}
                 {{ with .Params.volume }}<span> ({{ . }})</span>{{ end -}}
@@ -31,7 +31,7 @@
         </div>
 
         {{ if .Params.featured }}
-            <i data-feather="star" class="inline-block mr-1 text-sm text-yellow-400 w-4 h-4" fill="#f6e05e"></i>
+            <i data-feather="star" class="inline-block mr-1 text-sm text-ne-primary-dark w-4 h-4" fill="#FCD34D"></i>
         {{ end }}
     </div>
     {{ end }}

--- a/layouts/section/series.html
+++ b/layouts/section/series.html
@@ -21,10 +21,10 @@
                     {{ end }}
                     {{- .Title -}}
                 </div>
-            
-                <div class="flex flex-row flex-shrink-0 items-center text-gray-500 font-semibold tracking-tighter text-sm">
+
+                <div class="flex flex-row flex-shrink-0 items-center text-ne-on-surface font-semibold tracking-tighter text-sm">
                     {{ if .Params.featured }}
-                    <i data-feather="star" class="inline-block mr-1 text-sm text-yellow-400 w-4 h-4" fill="#f6e05e"></i>
+                    <i data-feather="star" class="inline-block mr-1 text-sm text-ne-primary-dark w-4 h-4" fill="#FCD34D"></i>
                     {{ end }}
                     {{- dateFormat "Jan 02" .PublishDate -}}
                 </div>

--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -9,7 +9,7 @@
     </div>
 </div>
 {{ else }}
-<div class="relative pl-16 pr-4 py-4 my-2 rounded-md text-blue-700 bg-blue-200">
+<div class="relative pl-16 pr-4 py-4 my-2 rounded-md text-ne-secondary bg-ne-secondary-lighter">
     <div>
         <i data-feather="info" class="absolute w-8 h-8" style="left: 0.75rem;"></i>
         {{- $inner | markdownify | emojify -}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,14 +4,40 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+            "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.10.4"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+            "dev": true
+        },
+        "@babel/highlight": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            }
+        },
         "@fullhuman/postcss-purgecss": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.3.0.tgz",
-            "integrity": "sha512-qnKm5dIOyPGJ70kPZ5jiz0I9foVOic0j+cOzNDoo8KoCf6HjicIZ99UfO2OmE7vCYSKAAepEwJtNzpiiZAh9xw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.0.0.tgz",
+            "integrity": "sha512-cvuOgMwIVlfgWcUMqg5p33NbGUxLwMrKtDKkm3QRfOo4PRVNR6+y/xd9OyXTVZiB1bIpKNJ0ZObYPWD3DRQDtw==",
             "dev": true,
             "requires": {
                 "postcss": "7.0.32",
-                "purgecss": "^2.3.0"
+                "purgecss": "^3.0.0"
             },
             "dependencies": {
                 "postcss": {
@@ -53,10 +79,10 @@
                 "fastq": "^1.6.0"
             }
         },
-        "@types/color-name": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+        "@types/parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
             "dev": true
         },
         "acorn": {
@@ -107,15 +133,6 @@
                 "picomatch": "^2.0.4"
             }
         },
-        "argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "requires": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
         "array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -129,17 +146,16 @@
             "dev": true
         },
         "autoprefixer": {
-            "version": "9.8.6",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
-            "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.0.2.tgz",
+            "integrity": "sha512-okBmu9OMdt6DNEcZmnl0IYVv8Xl/xYWRSnc2OJ9UJEOt1u30opG1B8aLsViqKryBaYv1SKB4f85fOGZs5zYxHQ==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.12.0",
-                "caniuse-lite": "^1.0.30001109",
+                "browserslist": "^4.14.7",
+                "caniuse-lite": "^1.0.30001157",
                 "colorette": "^1.2.1",
                 "normalize-range": "^0.1.2",
                 "num2fraction": "^1.2.2",
-                "postcss": "^7.0.32",
                 "postcss-value-parser": "^4.1.0"
             }
         },
@@ -175,15 +191,16 @@
             }
         },
         "browserslist": {
-            "version": "4.14.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
-            "integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
+            "version": "4.14.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
+            "integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001135",
-                "electron-to-chromium": "^1.3.571",
-                "escalade": "^3.1.0",
-                "node-releases": "^1.1.61"
+                "caniuse-lite": "^1.0.30001157",
+                "colorette": "^1.2.1",
+                "electron-to-chromium": "^1.3.591",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.66"
             }
         },
         "bytes": {
@@ -192,34 +209,10 @@
             "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
             "dev": true
         },
-        "caller-callsite": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-            "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-            "dev": true,
-            "requires": {
-                "callsites": "^2.0.0"
-            }
-        },
-        "caller-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-            "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-            "dev": true,
-            "requires": {
-                "caller-callsite": "^2.0.0"
-            }
-        },
         "callsites": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-            "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-            "dev": true
-        },
-        "camelcase": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true
         },
         "camelcase-css": {
@@ -229,9 +222,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001141",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001141.tgz",
-            "integrity": "sha512-EHfInJHoQTmlMdVZrEc5gmwPc0zyN/hVufmGHPbVNQwlk7tJfCmQ2ysRZMY2MeleBivALUTyyxXnQjK18XrVpA==",
+            "version": "1.0.30001159",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
+            "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==",
             "dev": true
         },
         "chalk": {
@@ -257,9 +250,9 @@
             }
         },
         "chokidar": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-            "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+            "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
             "dev": true,
             "requires": {
                 "anymatch": "~3.1.1",
@@ -269,18 +262,18 @@
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
-                "readdirp": "~3.4.0"
+                "readdirp": "~3.5.0"
             }
         },
         "cliui": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
             "dev": true,
             "requires": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^6.2.0"
+                "wrap-ansi": "^7.0.0"
             }
         },
         "color": {
@@ -325,9 +318,9 @@
             "dev": true
         },
         "commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+            "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
             "dev": true
         },
         "concat-map": {
@@ -337,15 +330,16 @@
             "dev": true
         },
         "cosmiconfig": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-            "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+            "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
             "dev": true,
             "requires": {
-                "import-fresh": "^2.0.0",
-                "is-directory": "^0.3.1",
-                "js-yaml": "^3.13.1",
-                "parse-json": "^4.0.0"
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
             }
         },
         "css-unit-converter": {
@@ -358,12 +352,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-            "dev": true
-        },
-        "decamelize": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
         "defined": {
@@ -389,6 +377,12 @@
                 "minimist": "^1.1.1"
             }
         },
+        "didyoumean": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
+            "integrity": "sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=",
+            "dev": true
+        },
         "dir-glob": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -399,9 +393,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.576",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.576.tgz",
-            "integrity": "sha512-uSEI0XZ//5ic+0NdOqlxp0liCD44ck20OAGyLMSymIWTEAtHKVJi6JM18acOnRgUgX7Q65QqnI+sNncNvIy8ew==",
+            "version": "1.3.603",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.603.tgz",
+            "integrity": "sha512-J8OHxOeJkoSLgBXfV9BHgKccgfLMHh+CoeRo6wJsi6m0k3otaxS/5vrHpMNSEYY4MISwewqanPOuhAtuE8riQQ==",
             "dev": true
         },
         "emoji-regex": {
@@ -420,21 +414,15 @@
             }
         },
         "escalade": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
-            "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
             "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
-        },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
         },
         "fast-glob": {
@@ -452,9 +440,9 @@
             }
         },
         "fastq": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-            "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+            "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
             "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
@@ -467,16 +455,6 @@
             "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
-            }
-        },
-        "find-up": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dev": true,
-            "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
             }
         },
         "fs-extra": {
@@ -503,6 +481,12 @@
             "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
             "dev": true,
             "optional": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -559,6 +543,15 @@
             "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
             "dev": true
         },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -578,31 +571,39 @@
             "dev": true
         },
         "import-cwd": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
-            "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+            "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
             "dev": true,
             "requires": {
-                "import-from": "^2.1.0"
+                "import-from": "^3.0.0"
             }
         },
         "import-fresh": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-            "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+            "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
             "dev": true,
             "requires": {
-                "caller-path": "^2.0.0",
-                "resolve-from": "^3.0.0"
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
             }
         },
         "import-from": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
-            "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+            "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
             "dev": true,
             "requires": {
-                "resolve-from": "^3.0.0"
+                "resolve-from": "^5.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+                    "dev": true
+                }
             }
         },
         "indexes-of": {
@@ -642,11 +643,14 @@
                 "binary-extensions": "^2.0.0"
             }
         },
-        "is-directory": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-            "dev": true
+        "is-core-module": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+            "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -675,20 +679,31 @@
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
         },
-        "js-yaml": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "isarray": "1.0.0"
             }
         },
-        "json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
         "jsonfile": {
@@ -701,19 +716,56 @@
                 "universalify": "^1.0.0"
             }
         },
-        "locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+        "line-column": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
+            "integrity": "sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=",
             "dev": true,
             "requires": {
-                "p-locate": "^4.1.0"
+                "isarray": "^1.0.0",
+                "isobject": "^2.0.0"
             }
+        },
+        "lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+            "dev": true
         },
         "lodash": {
             "version": "4.17.20",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
             "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+            "dev": true
+        },
+        "lodash.difference": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+            "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+            "dev": true
+        },
+        "lodash.forown": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-4.4.0.tgz",
+            "integrity": "sha1-hRFc8E9z75ZuztUlEdOJPMRmg68=",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
+        },
+        "lodash.groupby": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+            "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=",
+            "dev": true
+        },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
             "dev": true
         },
         "lodash.toarray": {
@@ -723,12 +775,63 @@
             "dev": true
         },
         "log-symbols": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+            "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1"
+                "chalk": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "merge2": {
@@ -762,6 +865,18 @@
             "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
+        "modern-normalize": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-1.0.0.tgz",
+            "integrity": "sha512-1lM+BMLGuDfsdwf3rsgBSrxJwAZHFIrQ8YR61xIqdHo0uNKI9M52wNpHSrliZATJp51On6JD0AfRxd4YGSU0lw==",
+            "dev": true
+        },
+        "nanoid": {
+            "version": "3.1.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.18.tgz",
+            "integrity": "sha512-rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA==",
+            "dev": true
+        },
         "node-emoji": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
@@ -772,9 +887,9 @@
             }
         },
         "node-releases": {
-            "version": "1.1.61",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
-            "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
+            "version": "1.1.67",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
+            "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
             "dev": true
         },
         "normalize-path": {
@@ -787,12 +902,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
-            "dev": true
-        },
-        "normalize.css": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
-            "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
             "dev": true
         },
         "num2fraction": {
@@ -822,45 +931,26 @@
                 "wrappy": "1"
             }
         },
-        "p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "requires": {
-                "p-try": "^2.0.0"
+                "callsites": "^3.0.0"
             }
-        },
-        "p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
-            "requires": {
-                "p-limit": "^2.2.0"
-            }
-        },
-        "p-try": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true
         },
         "parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+            "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
             "dev": true,
             "requires": {
+                "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
             }
-        },
-        "path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -893,20 +983,21 @@
             "dev": true
         },
         "postcss": {
-            "version": "7.0.35",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+            "version": "8.1.8",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.1.8.tgz",
+            "integrity": "sha512-hO6jFWBy0QnBBRaw+s0F4hVPKGDICec/nLNEG1D4qqw9/LBzWMkTjckqqELXAo0J42jN8GFZXtgQfezEaoG9gQ==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
+                "colorette": "^1.2.1",
+                "line-column": "^1.0.2",
+                "nanoid": "^3.1.16",
+                "source-map": "^0.6.1"
             }
         },
         "postcss-cli": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-7.1.2.tgz",
-            "integrity": "sha512-3mlEmN1v2NVuosMWZM2tP8bgZn7rO5PYxRRrXtdSyL5KipcgBDjJ9ct8/LKxImMCJJi3x5nYhCGFJOkGyEqXBQ==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-8.3.0.tgz",
+            "integrity": "sha512-GqWohD9VmH+LCe+xsv6VCdcgNylNBmsrbxJlyXUGteGGdcmazj2YxSiJMUmQpg8pE6LRox9idtsTB7JZq5a+rw==",
             "dev": true,
             "requires": {
                 "chalk": "^4.0.0",
@@ -915,21 +1006,20 @@
                 "fs-extra": "^9.0.0",
                 "get-stdin": "^8.0.0",
                 "globby": "^11.0.0",
-                "postcss": "^7.0.0",
-                "postcss-load-config": "^2.0.0",
-                "postcss-reporter": "^6.0.0",
+                "postcss-load-config": "^3.0.0",
+                "postcss-reporter": "^7.0.0",
                 "pretty-hrtime": "^1.0.3",
                 "read-cache": "^1.0.0",
-                "yargs": "^15.0.2"
+                "slash": "^3.0.0",
+                "yargs": "^16.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "^1.1.1",
                         "color-convert": "^2.0.1"
                     }
                 },
@@ -1016,65 +1106,72 @@
             }
         },
         "postcss-import": {
-            "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-12.0.1.tgz",
-            "integrity": "sha512-3Gti33dmCjyKBgimqGxL3vcV8w9+bsHwO5UrBawp796+jdardbcFl4RP5w/76BwNL7aGzpKstIfF9I+kdE8pTw==",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-13.0.0.tgz",
+            "integrity": "sha512-LPUbm3ytpYopwQQjqgUH4S3EM/Gb9QsaSPP/5vnoi+oKVy3/mIk2sc0Paqw7RL57GpScm9MdIMUypw2znWiBpg==",
             "dev": true,
             "requires": {
-                "postcss": "^7.0.1",
-                "postcss-value-parser": "^3.2.3",
+                "postcss-value-parser": "^4.0.0",
                 "read-cache": "^1.0.0",
                 "resolve": "^1.1.7"
-            },
-            "dependencies": {
-                "postcss-value-parser": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-                    "dev": true
-                }
             }
         },
         "postcss-js": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-2.0.3.tgz",
-            "integrity": "sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-3.0.3.tgz",
+            "integrity": "sha512-gWnoWQXKFw65Hk/mi2+WTQTHdPD5UJdDXZmX073EY/B3BWnYjO4F4t0VneTCnCGQ5E5GsCdMkzPaTXwl3r5dJw==",
             "dev": true,
             "requires": {
                 "camelcase-css": "^2.0.1",
-                "postcss": "^7.0.18"
+                "postcss": "^8.1.6"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "8.1.8",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.1.8.tgz",
+                    "integrity": "sha512-hO6jFWBy0QnBBRaw+s0F4hVPKGDICec/nLNEG1D4qqw9/LBzWMkTjckqqELXAo0J42jN8GFZXtgQfezEaoG9gQ==",
+                    "dev": true,
+                    "requires": {
+                        "colorette": "^1.2.1",
+                        "line-column": "^1.0.2",
+                        "nanoid": "^3.1.16",
+                        "source-map": "^0.6.1"
+                    }
+                }
             }
         },
         "postcss-load-config": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.2.tgz",
-            "integrity": "sha512-/rDeGV6vMUo3mwJZmeHfEDvwnTKKqQ0S7OHUi/kJvvtx3aWtyWG2/0ZWnzCt2keEclwN6Tf0DST2v9kITdOKYw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.0.0.tgz",
+            "integrity": "sha512-lErrN8imuEF1cSiHBV8MiR7HeuzlDpCGNtaMyYHlOBuJHHOGw6S4xOMZp8BbXPr7AGQp14L6PZDlIOpfFJ6f7w==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "^5.0.0",
-                "import-cwd": "^2.0.0"
+                "cosmiconfig": "^7.0.0",
+                "import-cwd": "^3.0.0"
             }
         },
         "postcss-nested": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.3.tgz",
-            "integrity": "sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.1.tgz",
+            "integrity": "sha512-ZHNSAoHrMtbEzjq+Qs4R0gHijpXc6F1YUv4TGmGaz7rtfMvVJBbu5hMOH+CrhEaljQpEmx5N/P8i1pXTkbVAmg==",
             "dev": true,
             "requires": {
-                "postcss": "^7.0.32",
-                "postcss-selector-parser": "^6.0.2"
+                "postcss-selector-parser": "^6.0.4"
             }
         },
         "postcss-reporter": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
-            "integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.0.1.tgz",
+            "integrity": "sha512-R9AK80KIqqMb+lwGRBcRkXS7r96VCTxrZvvrfibyA/dWjqctwx7leHMCC05A9HbW8PnChwOWwrmISwp5HQu5wg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.1",
-                "lodash": "^4.17.11",
-                "log-symbols": "^2.2.0",
-                "postcss": "^7.0.7"
+                "colorette": "^1.2.1",
+                "lodash.difference": "^4.5.0",
+                "lodash.forown": "^4.4.0",
+                "lodash.get": "^4.4.2",
+                "lodash.groupby": "^4.6.0",
+                "lodash.sortby": "^4.7.0",
+                "log-symbols": "^4.0.0"
             }
         },
         "postcss-selector-parser": {
@@ -1102,12 +1199,12 @@
             "dev": true
         },
         "purgecss": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-2.3.0.tgz",
-            "integrity": "sha512-BE5CROfVGsx2XIhxGuZAT7rTH9lLeQx/6M0P7DTXQH4IUc3BBzs9JUzt4yzGf3JrH9enkeq6YJBe9CTtkm1WmQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-3.0.0.tgz",
+            "integrity": "sha512-t3FGCwyX9XWV3ffvnAXTw6Y3Z9kNlcgm14VImNK66xKi5sdqxSA2I0SFYxtmZbAKuIZVckPdazw5iKL/oY/2TA==",
             "dev": true,
             "requires": {
-                "commander": "^5.0.0",
+                "commander": "^6.0.0",
                 "glob": "^7.0.0",
                 "postcss": "7.0.32",
                 "postcss-selector-parser": "^6.0.2"
@@ -1136,9 +1233,9 @@
             }
         },
         "readdirp": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-            "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+            "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
             "dev": true,
             "requires": {
                 "picomatch": "^2.2.1"
@@ -1168,25 +1265,20 @@
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
             "dev": true
         },
-        "require-main-filename": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-            "dev": true
-        },
         "resolve": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-            "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+            "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
             "dev": true,
             "requires": {
+                "is-core-module": "^2.1.0",
                 "path-parse": "^1.0.6"
             }
         },
         "resolve-from": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-            "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true
         },
         "reusify": {
@@ -1196,15 +1288,9 @@
             "dev": true
         },
         "run-parallel": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-            "dev": true
-        },
-        "set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+            "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
             "dev": true
         },
         "simple-swizzle": {
@@ -1234,12 +1320,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true
-        },
-        "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
         "string-width": {
@@ -1272,33 +1352,31 @@
             }
         },
         "tailwindcss": {
-            "version": "1.9.6",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.9.6.tgz",
-            "integrity": "sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.0.1.tgz",
+            "integrity": "sha512-57G3jdcVBWTPkHCNSAfDAo1Qp2Nkr4H6WnLD0luNFh1td+KwQp9FOVcqj0SYBH6qwVQJawzT+0/zLxzKmyznGw==",
             "dev": true,
             "requires": {
-                "@fullhuman/postcss-purgecss": "^2.1.2",
-                "autoprefixer": "^9.4.5",
-                "browserslist": "^4.12.0",
+                "@fullhuman/postcss-purgecss": "^3.0.0",
                 "bytes": "^3.0.0",
-                "chalk": "^3.0.0 || ^4.0.0",
-                "color": "^3.1.2",
+                "chalk": "^4.1.0",
+                "color": "^3.1.3",
                 "detective": "^5.2.0",
-                "fs-extra": "^8.0.0",
+                "didyoumean": "^1.2.1",
+                "fs-extra": "^9.0.1",
                 "html-tags": "^3.1.0",
                 "lodash": "^4.17.20",
+                "modern-normalize": "^1.0.0",
                 "node-emoji": "^1.8.1",
-                "normalize.css": "^8.0.1",
                 "object-hash": "^2.0.3",
-                "postcss": "^7.0.11",
-                "postcss-functions": "^3.0.0",
-                "postcss-js": "^2.0.0",
-                "postcss-nested": "^4.1.1",
-                "postcss-selector-parser": "^6.0.0",
+                "postcss-functions": "^3",
+                "postcss-js": "^3.0.3",
+                "postcss-nested": "^5.0.1",
+                "postcss-selector-parser": "^6.0.4",
                 "postcss-value-parser": "^4.1.0",
                 "pretty-hrtime": "^1.0.3",
                 "reduce-css-calc": "^2.1.6",
-                "resolve": "^1.14.2"
+                "resolve": "^1.19.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -1335,30 +1413,20 @@
                     "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
                 "has-flag": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+                "resolve": {
+                    "version": "1.19.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+                    "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.6"
+                        "is-core-module": "^2.1.0",
+                        "path-parse": "^1.0.6"
                     }
                 },
                 "supports-color": {
@@ -1369,12 +1437,6 @@
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-                    "dev": true
                 }
             }
         },
@@ -1405,16 +1467,10 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
         },
-        "which-module": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-            "dev": true
-        },
         "wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
@@ -1423,12 +1479,11 @@
             },
             "dependencies": {
                 "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "^1.1.1",
                         "color-convert": "^2.0.1"
                     }
                 },
@@ -1462,39 +1517,37 @@
             "dev": true
         },
         "y18n": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+            "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+            "dev": true
+        },
+        "yaml": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+            "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
             "dev": true
         },
         "yargs": {
-            "version": "15.4.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "version": "16.1.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.1.1.tgz",
+            "integrity": "sha512-hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==",
             "dev": true,
             "requires": {
-                "cliui": "^6.0.0",
-                "decamelize": "^1.2.0",
-                "find-up": "^4.1.0",
-                "get-caller-file": "^2.0.1",
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
                 "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
                 "string-width": "^4.2.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^18.1.2"
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
             }
         },
         "yargs-parser": {
-            "version": "18.1.3",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-            "dev": true,
-            "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-            }
+            "version": "20.2.4",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+            "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+            "dev": true
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "hugo-northeast",
-    "version": "0.9.1",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -983,15 +983,15 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.1.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.1.8.tgz",
-            "integrity": "sha512-hO6jFWBy0QnBBRaw+s0F4hVPKGDICec/nLNEG1D4qqw9/LBzWMkTjckqqELXAo0J42jN8GFZXtgQfezEaoG9gQ==",
+            "version": "8.1.10",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.1.10.tgz",
+            "integrity": "sha512-iBXEV5VTTYaRRdxiFYzTtuv2lGMQBExqkZKSzkJe+Fl6rvQrA/49UVGKqB+LG54hpW/TtDBMGds8j33GFNW7pg==",
             "dev": true,
             "requires": {
                 "colorette": "^1.2.1",
-                "line-column": "^1.0.2",
-                "nanoid": "^3.1.16",
-                "source-map": "^0.6.1"
+                "nanoid": "^3.1.18",
+                "source-map": "^0.6.1",
+                "vfile-location": "^3.2.0"
             }
         },
         "postcss-cli": {
@@ -1465,6 +1465,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "vfile-location": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz",
+            "integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==",
             "dev": true
         },
         "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hugo-northeast",
-    "version": "0.9.2",
+    "version": "1.0.0",
     "description": "A Hugo theme with Tailwindcss",
     "main": "index.js",
     "repository": "https://github.com/y1zhou/hugo-northeast",
@@ -11,7 +11,7 @@
     },
     "devDependencies": {
         "autoprefixer": "^10.0.2",
-        "postcss": "^8.1.8",
+        "postcss": "^8.1.10",
         "postcss-cli": "^8.3.0",
         "postcss-import": "^13.0.0",
         "tailwindcss": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hugo-northeast",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "description": "A Hugo theme with Tailwindcss",
     "main": "index.js",
     "repository": "https://github.com/y1zhou/hugo-northeast",
@@ -10,11 +10,11 @@
         "start": "hugo --gc --minify"
     },
     "devDependencies": {
-        "autoprefixer": "^9.8.6",
-        "postcss": "^7.0.35",
-        "postcss-cli": "^7.1.2",
-        "postcss-import": "^12.0.1",
-        "tailwindcss": "^1.9.6"
+        "autoprefixer": "^10.0.2",
+        "postcss": "^8.1.8",
+        "postcss-cli": "^8.3.0",
+        "postcss-import": "^13.0.0",
+        "tailwindcss": "^2.0.1"
     },
     "browserslist": [
         "last 1 version",

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ npm install
 
 Finally, add `theme = "hugo-northeast` in the `config.toml` file in the root directory of your Hugo website.
 
-The website is now good to go! Run `hugo server -D` to see a live preview of it. To build the website for deployment, run
+The website is now good to go! Run `hugo server -DF --disableFastRender` to see a live preview of it. To build the website for deployment, run
 
 ```bash
 hugo --gc --minify


### PR DESCRIPTION
- Adopting the breaking changes in Tailwind CSS 2.0, following [the official guide](https://tailwindcss.com/docs/upgrading-to-v2).
- Define a custom color scheme. To change the colors, one can simply modify the colors in `assets/css/tailwind-colors.js`.
- Clean the duplicated in-line CSS and abstract into the theme CSS files.