### PR TITLE
Hotfix of Tailwind CSS 2.0 changes

### DIFF
--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -20,8 +20,8 @@ mark {
     @apply bg-ne-primary-darker;
 }
 
-blockquote > p {
-    @apply text-ne-on-surface-dark;
+.article-container blockquote * {
+    @apply text-ne-on-surface-dark !important;
 }
 
 :not(pre) > code {

--- a/assets/css/light.css
+++ b/assets/css/light.css
@@ -21,8 +21,8 @@ mark {
     @apply bg-ne-primary-dark;
 }
 
-blockquote > p {
-    @apply text-ne-on-surface;
+.article-container blockquote * {
+    @apply text-ne-on-surface !important;
 }
 
 :not(pre) > code {

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -309,13 +309,7 @@ ul.pagination {
 }
 
 li.page-item {
-    @apply py-1 px-2;
-}
-
-@media (min-width: 768px) {
-    li.page-item {
-        @apply px-4;
-    }
+    @apply py-1 px-2 md:px-4;
 }
 
 li.page-item.active {

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -329,7 +329,7 @@ iframe.instagram-media,
 
 /* Unified buttons style */
 .round-button {
-    @apply rounded-full transition-all duration-150 ease-linear  hover:bg-ne-primary-dark;
+    @apply rounded-full transition-all duration-150 ease-linear hover:bg-ne-primary-dark hover:text-ne-on-primary;
 }
 
 .round-button button,

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -26,7 +26,7 @@
                 {{ end }}
 
                 {{/* Date and category */}}
-                <div class="flex flex-row justify-start items-center space-x-2 text-ne-on-surface text-sm divide-x-2">
+                <div class="flex flex-row justify-start items-center space-x-2 text-ne-on-surface text-sm divide-x-2 divide-ne-on-surface-lighter">
                     {{ with .PublishDate }}
                     <div class="flex flex-shrink-0 items-center">
                         {{ dateFormat "Jan 2, 2006" .Local -}}

--- a/layouts/partials/post-metadata.html
+++ b/layouts/partials/post-metadata.html
@@ -1,5 +1,5 @@
 <div
-    class="flex flex-row overflow-y-hidden overflow-x-auto w-full justify-start md:justify-center items-center space-x-4 text-ne-on-surface text-sm font-bold divide-x-2 ">
+    class="flex flex-row overflow-y-hidden overflow-x-auto w-full justify-start md:justify-center items-center space-x-4 text-ne-on-surface text-sm font-bold divide-x-2 divide-ne-on-surface-lighter">
     {{ with .PublishDate }}
     <div class="flex flex-shrink-0 items-center">
         <i data-feather="calendar" class="mr-1 w-4 h-4"></i>


### PR DESCRIPTION
- Text color in blockquotes weren't applied correctly.
- Color of icons in buttons in the publications page were too light.
- `:hover` in `@apply` in CSS files.
- `divide-color` for homepage cards and post metadata dividers.